### PR TITLE
feat(autocomplete): add quotes around an argument if it has spaces

### DIFF
--- a/src/client/interface/components/terminal/TerminalTextField.tsx
+++ b/src/client/interface/components/terminal/TerminalTextField.tsx
@@ -200,7 +200,13 @@ export function TerminalTextField({
 			newText = newText.sub(0, newText.size() - parts[parts.size() - 1].size());
 		}
 
-		newText += currentSuggestion.others[0];
+		let suggestion = currentSuggestion.others[0];
+
+		if (string.match(suggestion, "%s")[0] !== undefined) {
+			suggestion = `"${suggestion}"`;
+		}
+
+		newText += suggestion;
 		if (argIndex < commandArgs.size() - 1) {
 			newText += " ";
 		}


### PR DESCRIPTION
I wasn't sure if we needed this same type of function anywhere else in the autocomplete, so I just put it for arguments currently.