### PR TITLE
fix: brickcolor type

### DIFF
--- a/src/shared/builtin/types/color.ts
+++ b/src/shared/builtin/types/color.ts
@@ -227,7 +227,7 @@ export const BrickColorType = TypeBuilder.create<BrickColor>(
 	.suggestions(() => brickColorNameArray)
 	.build();
 
-const HEX_COLOR_PATTERN = "^#[%a%d]+$";
+const HEX_COLOR_PATTERN = "^#?%x%x%x%x%x%x$";
 
 function isHexColor(value: unknown): value is Color3 {
 	if (!typeIs(value, "string")) return false;

--- a/src/shared/builtin/types/color.ts
+++ b/src/shared/builtin/types/color.ts
@@ -222,7 +222,7 @@ export const BrickColorType = TypeBuilder.create<BrickColor>(
 	.transform((text) => {
 		if (!brickColorNames.has(text))
 			return TransformResult.err("Invalid BrickColor");
-		return TransformResult.ok(BrickColor[text as never]);
+		return TransformResult.ok(new BrickColor(text as BrickColorsByNumber[keyof BrickColorsByNumber]));
 	})
 	.suggestions(() => brickColorNameArray)
 	.build();


### PR DESCRIPTION
Calls the BrickColor constructor using the text argument instead of indexing the class object itself.

Also uses a more specific hex pattern to avoid warnings being thrown in the console when typing out a hex code.